### PR TITLE
✨ Move over mock_service_oas_get util from zgw-consumers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ Homepage = "https://github.com/maykinmedia/zgw-consumers-oas"
 "Source Code" = "https://github.com/maykinmedia/zgw-consumers-oas"
 
 [project.optional-dependencies]
+mocks = [
+    "requests-mock",
+]
 tests = [
     "pytest",
     "pytest-django",

--- a/zgw_consumers_oas/mocks.py
+++ b/zgw_consumers_oas/mocks.py
@@ -1,0 +1,10 @@
+from requests_mock import Mocker
+
+from .schema_loading import read_schema
+
+
+def mock_service_oas_get(m: Mocker, url: str, service: str, oas_url: str = "") -> None:
+    if not oas_url:
+        oas_url = f"{url}schema/openapi.yaml?v=3"
+    content = read_schema(service)
+    m.get(oas_url, content=content)


### PR DESCRIPTION
Open Zaak still relies on this to mock requests to get schemas when doing validation